### PR TITLE
allow pure number textboxes

### DIFF
--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -13,6 +13,8 @@ function widget(domain, label)
         return Checkbox(value=domain, label=label)
     elseif isa(domain, String)
         return Textbox(domain, label=label)
+    elseif isa(domain, Number)
+        return Textbox(typ = Number, value = domain, label=label)
     else
         # XXX: TODO: Add React.constant - a constant signal.
         error("There is no widget for the value ", domain)


### PR DESCRIPTION
`@manipulate` only recognized Strings as text boxes, with this PR it also knows what to do with numbers.

``` julia
@manipulate for μ in -5:5, σ in 0:5, min = -10, max = 10 
    dist = Normal(μ, σ)
    plot(x -> pdf(dist,x), min, max) 
end
```

edit: rebased on master 
