### PR TITLE
Various widget updates

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.4
 JSON
 Compat 0.8.0
 Reactive 0.3
-DataStructures 0.2.10
+DataStructures

--- a/src/IJulia/handle_msg.jl
+++ b/src/IJulia/handle_msg.jl
@@ -21,11 +21,12 @@ function handle_msg{T}(w::Button{T}, msg)
 end
 
 function handle_msg{view}(w::Options{view}, msg)
-        if msg.content["data"]["method"] == "backbone"
+        if msg.content["data"]["method"] == "backbone" &&
+                haskey(msg.content["data"]["sync_data"], "value") #sometimes it sends just selected_label, not value...
             IJulia.set_cur_msg(msg)
             if view == :SelectMultiple
                 keys = msg.content["data"]["sync_data"]["value"]
-                if map(key->haskey(w.options, key), keys) |> all
+                if all(map(key->haskey(w.options, key), keys))
                     recv_msg(w, map(key->w.options[key], keys))
                 end
             else

--- a/src/IJulia/handle_msg.jl
+++ b/src/IJulia/handle_msg.jl
@@ -1,7 +1,8 @@
 import Interact.recv_msg
 
 function handle_msg(w::InputWidget, msg)
-    if msg.content["data"]["method"] == "backbone"
+    if msg.content["data"]["method"] == "backbone" &&
+            haskey(msg.content["data"]["sync_data"], "value") #sometimes it sends just selected_label, not value...
         IJulia.set_cur_msg(msg)
         recv_msg(w, msg.content["data"]["sync_data"]["value"])
     end

--- a/src/IJulia/handle_msg.jl
+++ b/src/IJulia/handle_msg.jl
@@ -23,9 +23,16 @@ end
 function handle_msg{view}(w::Options{view}, msg)
         if msg.content["data"]["method"] == "backbone"
             IJulia.set_cur_msg(msg)
-            key = string(msg.content["data"]["sync_data"]["value"])
-            if haskey(w.options, key)
-                recv_msg(w, w.options[key])
+            if view == :SelectMultiple
+                keys = msg.content["data"]["sync_data"]["value"]
+                if map(key->haskey(w.options, key), keys) |> all
+                    recv_msg(w, map(key->w.options[key], keys))
+                end
+            else
+                key = string(msg.content["data"]["sync_data"]["value"])
+                if haskey(w.options, key)
+                    recv_msg(w, w.options[key])
+                end
             end
         end
 end

--- a/src/IJulia/statedict.jl
+++ b/src/IJulia/statedict.jl
@@ -1,3 +1,10 @@
+Interact.viewdict(s::Union{Slider, Progress}) =
+    Dict{Symbol, Any}(:orientation => s.orientation)
+
+Interact.viewdict(d::Options) =
+    Dict{Symbol, Any}(:tooltips => d.tooltips,
+                    :orientation => d.orientation)
+
 @compat Interact.statedict(s::Union{Slider, Progress}) =
     @compat Dict(:value=>s.value,
          :min=>first(s.range),
@@ -5,6 +12,7 @@
          :max=>last(s.range),
          :model_name => "FloatSliderModel",
          :_model_name => "FloatSliderModel",
+         :readout => s.readout,
          :readout_format => s.readout_format,
          :continuous_update=>s.continuous_update,
      )
@@ -15,6 +23,7 @@ Interact.statedict(d::Options) =
          :value => d.value_label,
          :icons=>d.icons,
          :tooltips=>d.tooltips,
+         :readout => d.readout,
          :_options_labels=>collect(keys(d.options)))
 
 function statedict(w::Widget)

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -26,6 +26,10 @@ function statedict(w)
     msg
 end
 
+function viewdict(w::Widget)
+    Dict()
+end
+
 # Convert e.g. JSON values into Julia values
 parse_msg{T <: Number}(::InputWidget{T}, v::AbstractString) = parse(T, v)
 parse_msg(::InputWidget{Bool}, v::Number) = v != 0

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -1,6 +1,6 @@
 module Interact
 
-using Reactive, Compat
+using Reactive, Compat, DataStructures
 
 import Base: mimewritable, writemime
 export signal, Widget, InputWidget

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -1,7 +1,7 @@
 import Base: convert, haskey, setindex!, getindex
 export slider, togglebutton, button,
        checkbox, textbox, textarea,
-       radiobuttons, dropdown, select,
+       radiobuttons, dropdown, selectone, selectmulti,
        togglebuttons, html, latex,
        progress, widget, selection_slider
 
@@ -275,8 +275,18 @@ radiobuttons: see the help for `dropdown`
 radiobuttons(opts; kwargs...) =
     Options(:RadioButtons, opts; kwargs...)
 
-select(opts; kwargs...) =
+"""
+selectone: see the help for `dropdown`
+"""
+selectone(opts; kwargs...) =
     Options(:Select, opts; kwargs...)
+
+"""
+selectmulti: see the help for `dropdown`
+"""
+selectmulti(opts; signal=Signal(collect(opts)[1:1]), kwargs...) = begin
+    Options(:SelectMultiple, opts; signal=signal, kwargs...)
+end
 
 """
 togglebuttons: see the help for `dropdown`

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -16,6 +16,8 @@ type Slider{T<:Number} <: InputWidget{T}
     label::AbstractString
     value::T
     range::Range{T}
+    orientation::String
+    readout::Bool
     readout_format::AbstractString
     continuous_update::Bool
 end
@@ -25,7 +27,7 @@ medianelement(r::Range) = r[(1+length(r))>>1]
 
 slider(args...) = Slider(args...)
 """
-    slider(range; value, signal, label="", continuous_update=true)
+    slider(range; value, signal, label="", readout=true, continuous_update=true)
 
 Create a slider widget with the specified `range`. Optionally specify
 the starting `value` (defaults to the median of `range`), provide the
@@ -36,9 +38,11 @@ slider{T}(range::Range{T};
           value=medianelement(range),
           signal::Signal{T}=Signal(value),
           label="",
+          orientation="horizontal",
+          readout=true,
           readout_format=T <: Integer ? "d" : ".3f",
           continuous_update=true) =
-              Slider(signal, label, value, range, readout_format, continuous_update)
+              Slider(signal, label, value, range, orientation, readout, readout_format, continuous_update)
 
 ######################### Checkbox ###########################
 
@@ -213,6 +217,8 @@ type Options{view, T} <: InputWidget{T}
     options::OptionDict
     icons::AbstractArray
     tooltips::AbstractArray
+    readout::Bool
+    orientation::AbstractString
 end
 
 Options(view::Symbol, options::OptionDict;
@@ -222,9 +228,11 @@ Options(view::Symbol, options::OptionDict;
         icons=[],
         tooltips=[],
         typ=valtype(options.dict),
-        signal=Signal(valtype(options.dict), value)) =
+        signal=Signal(valtype(options.dict), value),
+        readout=true,
+        orientation="horizontal") =
     Options{view, typ}(signal, label, value, value_label,
-                       options, icons, tooltips)
+                       options, icons, tooltips, readout, orientation)
 
 addoption(opts, v::NTuple{2}) = opts[string(v[1])] = v[2]
 addoption(opts, v) = opts[string(v)] = v
@@ -322,11 +330,16 @@ type Progress <: Widget
     label::AbstractString
     value::Int
     range::Range
+    orientation::String
+    readout::Bool
+    readout_format::String
+    continuous_update::Bool
 end
 
 progress(args...) = Progress(args...)
-progress(;label="", value=0, range=0:100) =
-    Progress(label, value, range)
+progress(;label="", value=0, range=0:100, orientation="horizontal",
+            readout=true, readout_format="d", continuous_update=true) =
+    Progress(label, value, range, orientation, readout, readout_format, continuous_update)
 
 # Make a widget out of a domain
 widget(x::Signal, label="") = x

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -1,7 +1,7 @@
 import Base: convert, haskey, setindex!, getindex
 export slider, togglebutton, button,
        checkbox, textbox, textarea,
-       radiobuttons, dropdown, selectone, selectmulti,
+       radiobuttons, dropdown, selection,
        togglebuttons, html, latex,
        progress, widget, selection_slider
 
@@ -361,17 +361,18 @@ radiobuttons(opts; kwargs...) =
     Options(:RadioButtons, opts; kwargs...)
 
 """
-selectone: see the help for `dropdown`
+selection: see the help for `dropdown`
 """
-selectone(opts; kwargs...) =
-    Options(:Select, opts; kwargs...)
-
-"""
-selectmulti: see the help for `dropdown`
-"""
-selectmulti(opts; signal=Signal(collect(opts)[1:1]), kwargs...) = begin
-    Options(:SelectMultiple, opts; signal=signal, kwargs...)
+function selection(opts; multi=false, kwargs...)
+    if multi
+        signal = Signal(collect(opts)[1:1])
+        Options(:SelectMultiple, opts; signal=signal, kwargs...)
+    else
+        Options(:Select, opts; kwargs...)
+    end
 end
+
+Base.@deprecate select(opts; kwargs...) selection(opts, kwargs...)
 
 """
 togglebuttons: see the help for `dropdown`

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -421,7 +421,7 @@ progress(;label="", value=0, range=0:100, orientation="horizontal",
 # Make a widget out of a domain
 widget(x::Signal, label="") = x
 widget(x::Widget, label="") = x
-widget(x::Range, label="") = slider(x, label=label)
+widget(x::Range, label="") = selection_slider(x, label=label)
 widget(x::AbstractVector, label="") = togglebuttons(x, label=label)
 widget(x::Associative, label="") = togglebuttons(x, label=label)
 widget(x::Bool, label="") = checkbox(x, label=label)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -288,6 +288,7 @@ Options(view::Symbol, options::OptionDict;
         orientation="horizontal",
         syncsig=true) = begin
     signal, value = init_wsigval(signal, value; typ=typ, default=options[value_label])
+    typ = typeof(value)
     ow = Options{view, typ}(signal, label, value, value_label,
                     options, icons, tooltips, readout, orientation)
     if syncsig

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -13,7 +13,8 @@ function init_wsigval(signal, value; default=value, typ=typeof(default))
         if value == nothing
             value = default
         end
-        signal = Signal(typ, value)
+        _typ = typ === nothing ? typeof(value) : typ
+        signal = Signal(_typ, value)
     else
         #signal set
         if value == nothing
@@ -167,7 +168,7 @@ end
 function Textbox(; label="",
                  value=nothing,
                  # Allow unicode characters even if initiated with ASCII
-                 typ=String,
+                 typ=nothing,
                  range=nothing,
                  signal=nothing,
                  syncsig=true)
@@ -177,12 +178,12 @@ function Textbox(; label="",
              ))
     end
     signal, value = init_wsigval(signal, value; typ=typ, default="")
-    t = Textbox{typ}(signal, label, range, value)
+    t = Textbox(signal, label, range, value)
     if syncsig
         #keep the slider updated if the signal changes
         keep_updated(new_value) = begin
-            if string(new_value) != t.value
-                t.value = string(new_value)
+            if new_value != t.value
+                t.value = new_value
                 update_view(t)
             end
             nothing

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -3,7 +3,7 @@ export slider, togglebutton, button,
        checkbox, textbox, textarea,
        radiobuttons, dropdown, select,
        togglebuttons, html, latex,
-       progress, widget
+       progress, widget, selection_slider
 
 const Empty = VERSION < v"0.4.0-dev" ? Nothing : Void
 
@@ -283,6 +283,12 @@ togglebuttons: see the help for `dropdown`
 """
 togglebuttons(opts; kwargs...) =
     Options(:ToggleButtons, opts; kwargs...)
+
+"""
+selection_slider: see the help for `dropdown`
+"""
+selection_slider(opts; kwargs...) =
+    Options(:SelectionSlider, opts; kwargs...)
 
 ### Output Widgets
 

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -169,14 +169,28 @@ function Textbox(; label="",
                  # Allow unicode characters even if initiated with ASCII
                  typ=String,
                  range=nothing,
-                 signal=nothing)
+                 signal=nothing,
+                 syncsig=true)
     if isa(value, AbstractString) && range != nothing
         throw(ArgumentError(
                "You cannot set a range on a string textbox"
              ))
     end
     signal, value = init_wsigval(signal, value; typ=typ, default="")
-    Textbox{typ}(signal, label, range, value)
+    t = Textbox{typ}(signal, label, range, value)
+    if syncsig
+        #keep the slider updated if the signal changes
+        keep_updated(new_value) = begin
+            if string(new_value) != t.value
+                t.value = string(new_value)
+                update_view(t)
+            end
+            nothing
+        end
+        preserve(map(keep_updated, signal; typ=Void))
+    end
+    t
+
 end
 
 textbox(;kwargs...) = Textbox(;kwargs...)

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -1,0 +1,397 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "IJulia.set_verbose()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Manual Test Notebook\n",
+    "\n",
+    "Run each cell, check for expected behaviour and check the browser console for errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "csliders = Widget[]\n",
+    "x = slider(0:.1:2pi, label=\"x\")\n",
+    "s = map(a -> slider(-1:.05:1, value=sin(2a), label=\"sin(2x)\"), signal(x))\n",
+    "c = map(signal(x)) do a\n",
+    "    s = slider(-1:.05:1, value=cos(2a), label=\"cos(2x)\")\n",
+    "    push!(csliders, s)\n",
+    "    s\n",
+    "end\n",
+    "chosen_val = flatten(map(w->signal(w), signal(c); typ=Signal); typ=Any)\n",
+    "first_slider = value(c)\n",
+    "map(display, [x,s,c,signal(first_slider),chosen_val]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#Signal{Widget} display, updating - move the slider, click \"checkbox\", click the checkbox - stuff should update\n",
+    "widget_choice = togglebuttons([\"slider\",\"checkbox\"], label=\"choose a widget\")\n",
+    "slider_to_show = slider(1:10; label=\"killr slider\")\n",
+    "checkbox_to_show = checkbox(true; label=\"my new checkcheck\")\n",
+    "widget_chosen = map(x->x==\"slider\"? slider_to_show : checkbox_to_show, signal(widget_choice); typ=Widget);\n",
+    "\n",
+    "map(display, (widget_choice, widget_chosen, signal(checkbox_to_show), signal(slider_to_show)));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#these shoudl be in sync with the above, but disappear when you click the widget selector above\n",
+    "map(display, (checkbox_to_show, slider_to_show));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#Same again but creating a new slider each time, plus flatten\n",
+    "count = 0\n",
+    "widget_choice = togglebuttons([\"slider\",\"checkbox\"], label=\"choose a widget\")\n",
+    "widget_chosen = map(signal(widget_choice); typ=Widget) do x\n",
+    "    global count += 1; \n",
+    "    x==\"slider\"? slider(1:10; label=\"killr slider $count\") : checkbox(true; label=\"my new checkcheck $count\") \n",
+    "end;\n",
+    "\n",
+    "chosen_val = flatten(map(w->signal(w), widget_chosen; typ=Signal); typ=Any)\n",
+    "map(display, (widget_choice, widget_chosen, chosen_val));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "#check sync as above\n",
+    "chosen_val = flatten(map(w->signal(w), widget_chosen; typ=Signal); typ=Any)\n",
+    "map(display, (widget_choice, widget_chosen, chosen_val));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#Signal{Widget} with same Widget type\n",
+    "#XXX sometimes the buttons can get out of order - please report if you have reproduction steps\n",
+    "eb=togglebuttons([1,2,3])\n",
+    "display(eb)\n",
+    "uuid=[[0,1],[0,1,2],[0,2]]\n",
+    "ub = map(x->togglebuttons(uuid[x]),eb.signal)\n",
+    "ub40 = flatten(map(w->signal(w), signal(ub); typ=Signal); typ=Any)\n",
+    "display.([ub, ub40]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#Slider options: vertical, no readout \n",
+    "s1 = slider(-1:.05:1, value=sin(2), label=\"vert\", orientation=\"vertical\")\n",
+    "s2 = slider(-1:.05:1, value=sin(2), label=\"no readout\", signal=signal(s1), orientation=\"horizontal\", readout=false)\n",
+    "display.([s1,s2]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pboy = progress()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "update!(pboy,50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Select Slider with value set via textbox, type 9, 99, 999, 9999\n",
+    "exprange = map(x->2^x,1:0.01:10)\n",
+    "selslide = selection_slider(exprange, label=\"exponential value\")\n",
+    "sel = signal(selslide)\n",
+    "txtbox = textbox(; label=\"set slider value\")\n",
+    "nearest(arr, val) = indmin(abs(val .- arr))\n",
+    "map(signal(txtbox)) do txt\n",
+    "    val = tryparse(Float64, txt)\n",
+    "    if !isnull(val)\n",
+    "        idx = nearest(exprange,  get(val)) #\n",
+    "        push!(signal(selslide), exprange[idx])\n",
+    "    end\n",
+    "end\n",
+    "map(display, (selslide, sel, txtbox));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "push!(signal(selslide), 30) #slider won't update but signal will - not a bug, but would be cool if it worked"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Same but vertical select slider, try 1,10,100,1000,10000\n",
+    "exprange = map(x->2^x,1:0.01:10)\n",
+    "selslidev = selection_slider(exprange, label=\"exponential value\", orientation=\"vertical\")\n",
+    "sel = signal(selslidev)\n",
+    "txtbox = textbox(; label=\"set slider value\")\n",
+    "nearest(arr, val) = indmin(abs(val .- arr))\n",
+    "map(signal(txtbox)) do txt\n",
+    "    val = tryparse(Float64, txt)\n",
+    "    if !isnull(val)\n",
+    "        idx = nearest(exprange,  get(val)) #\n",
+    "        push!(signal(selslidev), exprange[idx])\n",
+    "    end\n",
+    "end\n",
+    "map(display, (selslidev, sel, txtbox));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# ctrl/cmd click for multiple values\n",
+    "mse = selectmulti(enumerate([\"fred\",2,1 + 0.5im, 0.3]) |> collect)\n",
+    "ms = selectmulti([\"fred\",2,1 + 0.5im, 0.3])\n",
+    "display.([ms,signal(ms)]);\n",
+    "# display.([mse,signal(mse)]); Currently broken, should work;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ss = selectone(11:20)\n",
+    "display.([ss,signal(ss)]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Update options value_label displayed by pushing value to signal\n",
+    "fmult = Signal(Float64, 1e9) #GHz\n",
+    "w_fmult = togglebuttons([(\"kHz\", 1e3), (\"MHz\", 1e6), (\"GHz\", 1e9)], value=value(fmult), signal=fmult)\n",
+    "display.([w_fmult, signal(w_fmult)]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#run this multiple times, val should match selected toggle button\n",
+    "val = rand([1e3,1e6,1e9])\n",
+    "push!(fmult, val)\n",
+    "val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#slider stays synced with sig\n",
+    "s4 = slider(12:20)\n",
+    "display.([s4, signal(s4)]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#slider above should move to 13\n",
+    "push!(signal(s4), 13)\n",
+    "update_view(s4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#syncsig=false stays doesn't stay synced with sig\n",
+    "s5 = slider(12:20; syncsig=false)\n",
+    "display.([s5, signal(s5)]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#slider above *shouldn't* move to 13, but signal below should show 13\n",
+    "push!(signal(s5), 13)\n",
+    "update_view(s5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Print during update\n",
+    "@manipulate for i in 1:10\n",
+    "    @show i\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#byo signal\n",
+    "ss = Signal(3)\n",
+    "s1= slider(0:10; signal=ss)\n",
+    "map(display, (s1,ss));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#Byo Signal and init value\n",
+    "fx = Signal(0.0)\n",
+    "x = slider(0:.1:2pi, label=\"x\")\n",
+    "y = map(v -> slider(-1:.05:1, value=sin(v), signal=fx, label=\"f(x)\"), signal(x))\n",
+    "#init value only\n",
+    "z = map(a -> slider(-1:.05:1, value=sin(2a), label=\"sin(2x)\"), signal(x))\n",
+    "ssz = flatten(map(zslider->signal(zslider), signal(z)))\n",
+    "sinx = map(xv->round(sin(xv), 3), signal(x))\n",
+    "sin2x = map(xv->round(sin(2xv), 3), signal(x))\n",
+    "display.([x, y, z, signal(x), fx, sinx, ssz, sin2x]);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.5.0",
+   "language": "julia",
+   "name": "julia-0.5"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.5.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -295,8 +295,8 @@
    "outputs": [],
    "source": [
     "# multi-select - ctrl/cmd or shift click for multiple values\n",
-    "mse = selectmulti(enumerate([\"fred\",2,1 + 0.5im, 0.3]) |> collect)\n",
-    "ms = selectmulti([\"fred\",2,1 + 0.5im, 0.3])\n",
+    "mse = selection(enumerate([\"fred\",2,1 + 0.5im, 0.3]) |> collect, multi=true)\n",
+    "ms = selection([\"fred\",2,1 + 0.5im, 0.3], multi=true)\n",
     "display.([ms,signal(ms)]);\n",
     "# display.([mse,signal(mse)]); Currently broken, should work;"
    ]
@@ -309,7 +309,7 @@
    },
    "outputs": [],
    "source": [
-    "ss = selectone(11:20)\n",
+    "ss = selection(11:20)\n",
     "display.([ss,signal(ss)]);"
    ]
   },

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -24,11 +24,23 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "using Interact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
    "source": [
+    "#Dependent sliders\n",
     "csliders = Widget[]\n",
     "x = slider(0:.1:2pi, label=\"x\")\n",
     "s = map(a -> slider(-1:.05:1, value=sin(2a), label=\"sin(2x)\"), signal(x))\n",
@@ -67,7 +79,7 @@
    },
    "outputs": [],
    "source": [
-    "#these shoudl be in sync with the above, but disappear when you click the widget selector above\n",
+    "#these should be in sync with the above, but disappear when you click the widget selector above\n",
     "map(display, (checkbox_to_show, slider_to_show));"
    ]
   },
@@ -145,7 +157,7 @@
    },
    "outputs": [],
    "source": [
-    "pboy = progress()"
+    "pboy = progress() #should show all grey, then some colour when you run the cell below"
    ]
   },
   {
@@ -168,19 +180,41 @@
    "outputs": [],
    "source": [
     "# Select Slider with value set via textbox, type 9, 99, 999, 9999\n",
+    "# Value should be the value from the textbox, changes in slider should update teh textbox and vice-versa \n",
+    "\n",
     "exprange = map(x->2^x,1:0.01:10)\n",
-    "selslide = selection_slider(exprange, label=\"exponential value\")\n",
-    "sel = signal(selslide)\n",
-    "txtbox = textbox(; label=\"set slider value\")\n",
+    "init_val = first(exprange)\n",
+    "\n",
+    "#create slider\n",
+    "expslide = selection_slider(exprange, label=\"exponential value\")\n",
+    "\n",
+    "#create textbox\n",
+    "txtbox = textbox(string(init_val); label=\"set slider value\")\n",
     "nearest(arr, val) = indmin(abs(val .- arr))\n",
-    "map(signal(txtbox)) do txt\n",
+    "\n",
+    "#holds the last valid float value of what's in the textbox\n",
+    "output_valsig = foldp(init_val, signal(txtbox)) do prev, txt\n",
     "    val = tryparse(Float64, txt)\n",
-    "    if !isnull(val)\n",
-    "        idx = nearest(exprange,  get(val)) #\n",
-    "        push!(signal(selslide), exprange[idx])\n",
-    "    end\n",
+    "    isnull(val) ? prev : get(val)\n",
     "end\n",
-    "map(display, (selslide, sel, txtbox));"
+    "\n",
+    "#find the nearest value to what's in the textbox, and update the slider's signal with it \n",
+    "map(output_valsig) do val\n",
+    "    idx = nearest(exprange, val)\n",
+    "    if value(signal(expslide)) != exprange[idx]\n",
+    "        push!(signal(expslide), exprange[idx])\n",
+    "    end\n",
+    "end |> preserve\n",
+    "\n",
+    "#if the slider moves, update the txt box\n",
+    "map(signal(expslide)) do sliderval\n",
+    "    if nearest(exprange, value(output_valsig)) != nearest(exprange, sliderval)\n",
+    "        push!(signal(txtbox), string(sliderval))\n",
+    "    end\n",
+    "end |> preserve\n",
+    "\n",
+    "#display the widgets and the slider's signal's value\n",
+    "display.([expslide, txtbox, signal(expslide), signal(txtbox), signal(output_valsig)]);"
    ]
   },
   {
@@ -191,7 +225,18 @@
    },
    "outputs": [],
    "source": [
-    "push!(signal(selslide), 30) #slider won't update but signal will - not a bug, but would be cool if it worked"
+    "push!(signal(expslide), 30) #should update textbox and slider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "push!(signal(txtbox), \"50\") #should update textbox and slider"
    ]
   },
   {
@@ -203,19 +248,42 @@
    "outputs": [],
    "source": [
     "# Same but vertical select slider, try 1,10,100,1000,10000\n",
+    "# Select Slider with value set via textbox, type 9, 99, 999, 9999\n",
+    "# Value should be the value from the textbox, changes in slider should update teh textbox and vice-versa \n",
+    "\n",
     "exprange = map(x->2^x,1:0.01:10)\n",
-    "selslidev = selection_slider(exprange, label=\"exponential value\", orientation=\"vertical\")\n",
-    "sel = signal(selslidev)\n",
-    "txtbox = textbox(; label=\"set slider value\")\n",
+    "init_val = first(exprange)\n",
+    "\n",
+    "#create slider\n",
+    "expslide = selection_slider(exprange, label=\"exponential value\", orientation=\"vertical\")\n",
+    "\n",
+    "#create textbox\n",
+    "txtbox = textbox(string(init_val); label=\"set slider value\")\n",
     "nearest(arr, val) = indmin(abs(val .- arr))\n",
-    "map(signal(txtbox)) do txt\n",
+    "\n",
+    "#holds the last valid float value of what's in the textbox\n",
+    "output_valsig = foldp(init_val, signal(txtbox)) do prev, txt\n",
     "    val = tryparse(Float64, txt)\n",
-    "    if !isnull(val)\n",
-    "        idx = nearest(exprange,  get(val)) #\n",
-    "        push!(signal(selslidev), exprange[idx])\n",
-    "    end\n",
+    "    isnull(val) ? prev : get(val)\n",
     "end\n",
-    "map(display, (selslidev, sel, txtbox));"
+    "\n",
+    "#find the nearest value to what's in the textbox, and update the slider's signal with it \n",
+    "map(output_valsig) do val\n",
+    "    idx = nearest(exprange, val)\n",
+    "    if value(signal(expslide)) != exprange[idx]\n",
+    "        push!(signal(expslide), exprange[idx])\n",
+    "    end\n",
+    "end |> preserve\n",
+    "\n",
+    "#if the slider moves, update the txt box\n",
+    "map(signal(expslide)) do sliderval\n",
+    "    if nearest(exprange, value(output_valsig)) != nearest(exprange, sliderval)\n",
+    "        push!(signal(txtbox), string(sliderval))\n",
+    "    end\n",
+    "end |> preserve\n",
+    "\n",
+    "#display the widgets and the slider's signal's value\n",
+    "display.([expslide, txtbox, signal(expslide), signal(txtbox), signal(output_valsig)]);"
    ]
   },
   {
@@ -226,7 +294,7 @@
    },
    "outputs": [],
    "source": [
-    "# ctrl/cmd click for multiple values\n",
+    "# multi-select - ctrl/cmd or shift click for multiple values\n",
     "mse = selectmulti(enumerate([\"fred\",2,1 + 0.5im, 0.3]) |> collect)\n",
     "ms = selectmulti([\"fred\",2,1 + 0.5im, 0.3])\n",
     "display.([ms,signal(ms)]);\n",
@@ -253,7 +321,7 @@
    },
    "outputs": [],
    "source": [
-    "# Update options value_label displayed by pushing value to signal\n",
+    "# Update options value_label displayed by pushing value to signal, run cell below\n",
     "fmult = Signal(Float64, 1e9) #GHz\n",
     "w_fmult = togglebuttons([(\"kHz\", 1e3), (\"MHz\", 1e6), (\"GHz\", 1e9)], value=value(fmult), signal=fmult)\n",
     "display.([w_fmult, signal(w_fmult)]);"
@@ -333,7 +401,7 @@
    },
    "outputs": [],
    "source": [
-    "# Print during update\n",
+    "# Print during update (when slider moves)\n",
     "@manipulate for i in 1:10\n",
     "    @show i\n",
     "end"
@@ -372,11 +440,6 @@
     "sin2x = map(xv->round(sin(2xv), 3), signal(x))\n",
     "display.([x, y, z, signal(x), fx, sinx, ssz, sin2x]);"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
1. Adds SelectionSlider widget (`selection_slider`)
1. Adds SelectMultiple widget (`selectmulti`)
1. Renames `select` to `selectone` (to avoid name conflict with Base.select)
1. Enables vertical sliders (`orientation = "vertical"`)
1. Makes readout optional on sliders (`readout=false`)
1. Widget signals sync to the display of the widget better
1. Adds a notebook for manual testing

More info in the commit messages.

N.b. Each commit is mostly atomic, I could make multiple PRs if it suits you better. The first commit shown below is the Signal{Widget} one from #131