### PR TITLE
Adds `set!` function

### DIFF
--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -402,13 +402,15 @@
     "#Byo Signal and init value\n",
     "fx = Signal(0.0)\n",
     "x = slider(0:.1:2pi, label=\"x\")\n",
-    "y = map(v -> slider(-1:.05:1, value=sin(v), signal=fx, label=\"f(x)\"), signal(x))\n",
+    "y = map(v -> slider(-1:.05:1, value=sin(v), signal=fx, label=\"sin(x)\"), signal(x))\n",
     "#init value only\n",
     "z = map(a -> slider(-1:.05:1, value=sin(2a), label=\"sin(2x)\"), signal(x))\n",
     "ssz = flatten(map(zslider->signal(zslider), signal(z)))\n",
     "sinx = map(xv->round(sin(xv), 3), signal(x))\n",
     "sin2x = map(xv->round(sin(2xv), 3), signal(x))\n",
-    "display.([x, y, z, signal(x), fx, sinx, ssz, sin2x]);"
+    "#top 3 values should be the same as the slider readouts after you move x (but not the other 2 sliders)\n",
+    "#next two should be ~= sliders 2 and 3 at all times\n",
+    "display.([x, y, z, signal(x), sinx, sin2x, fx, ssz]);"
    ]
   },
   {
@@ -425,6 +427,39 @@
     "s2 = slider(11:0.1:20; orientation=\"vertical\"); \n",
     "layout = hbox(vbox(s1,cb), s2)\n",
     "display.([layout, map(signal, (cb,s1,s2))...]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#sin and cos are types that are subtypes of Function, make sure Options can generalise inputs to be of type Function\n",
+    "#clicking the buttons should update the \"sin (generic function with 10 methods)\" output\n",
+    "using Interact\n",
+    "t = togglebuttons([sin,cos])\n",
+    "display.([t, signal(t), eltype(signal(t))])\n",
+    "@show typeof.([sin,cos]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sldmin = slider(0:.01:10.0, label=\"min value\")\n",
+    "sldstep = slider(0.01:.01:1, label=\"step size\")\n",
+    "sldmax = slider(10.0:.1:20.0, label=\"max value\")\n",
+    "sldrange = map((vmin, vstep, vmax)->vmin:vstep:vmax, signal(sldmin), signal(sldstep), signal(sldmax))\n",
+    "s1 = slider(.01:.5:15.0)\n",
+    "set!(s1, :range, sldrange)\n",
+    "display.([sldmin, sldstep, sldmax, s1, sldrange]);"
    ]
   },
   {


### PR DESCRIPTION
`set!(w::Widget, fld::Symbol, val)`

Set the value of a widget property and update all displayed instances of the
widget. If `val` is a `Signal`, then updates to that signal will be reflected in
widget instances/views.

If `fld` is `:value`, `val` is also `push!`ed to `signal(w)`