### PR TITLE
RFC manipulate changes

### DIFF
--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -305,5 +305,13 @@ function create_widget_signal{T<:Widget}(s::Signal{T})
     end
 end
 
+#Manipulate Helpers
+typealias ITypes Union{Signal,Widget}
+display_dict(x::Tuple{Vararg{ITypes}}) = begin
+    foreach(display,x)
+    Dict()
+end
+metadata(x::Tuple{Vararg{ITypes}}) = Dict()
+
 include("statedict.jl")
 include("handle_msg.jl")

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -35,8 +35,11 @@ macro manipulate(expr)
         bindings = [expr.args[1]]
     end
     syms = symbols(bindings)
-    Expr(:let, Expr(:block,
-                    display_widgets(syms)...,
-                    esc(map_block(block, syms))),
-         map(make_widget, bindings)...)
+    Expr(:let,
+            Expr(:tuple,
+                map(sym->esc(sym), syms)...,
+                esc(map_block(block, syms))
+            ),
+            map(make_widget, bindings)...
+    )
 end

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -453,6 +453,7 @@
    },
    "outputs": [],
    "source": [
+    "# set! tests\n",
     "sldmin = slider(0:.01:10.0, label=\"min value\")\n",
     "sldstep = slider(0.01:.01:1, label=\"step size\")\n",
     "sldmax = slider(10.0:.1:20.0, label=\"max value\")\n",
@@ -469,7 +470,19 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "using Compose\n",
+    "\n",
+    "@manipulate for \n",
+    "    paused = false,\n",
+    "    dt = fpswhen(map(!, signal(paused)), 30),\n",
+    "    t = foldp(+, 0., dt),                    # add up the time deltas to get time\n",
+    "    gravity = 0:0.01:5,                      # some sort of gravity\n",
+    "    color = [\"tomato\", \"cyan\"]               # color the ball\n",
+    "\n",
+    "    compose(context(0.5, 1-abs(sin(t*gravity)), 0.1, 0.1), fill(parse(Colorant, color)), circle())\n",
+    "end"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
So this is a proposal to:

1. remedy #12 
1. allow multiple values to be returned by manipulate

It doesn't display widgets by default, but adds a method to `display_dict and metadata for (::Tuple{Vararg{Union{Signal,Widget}}}` which will display the widgets and the signals. `Out[x]` fro the previous cell still holds the correct result somehow so that's cool.

Also if you return a N-tuple from manipulate it will create N signals.