### PR TITLE
A few fixes

### DIFF
--- a/src/IJulia/handle_msg.jl
+++ b/src/IJulia/handle_msg.jl
@@ -33,6 +33,7 @@ function handle_msg{view}(w::Options{view}, msg)
             else
                 key = string(msg.content["data"]["sync_data"]["value"])
                 if haskey(w.options, key)
+                    w.value_label = key
                     recv_msg(w, w.options[key])
                 end
             end

--- a/src/IJulia/ijulia.js
+++ b/src/IJulia/ijulia.js
@@ -24,15 +24,18 @@
             var _src = 'data:' + type + ';base64,' + val;
 	    $(container).find("img").attr('src', _src);
 	    break;
+	case "text/latex":
+		if (MathJax){
+			var math = MathJax.Hub.getAllJax(container)[0];
+			MathJax.Hub.Queue(["Text", math, val.replace(/^\${1,2}|\${1,2}$/g, '')]);
+			break;
+		}
 	default:
 	    var toinsert = OutputArea.append_map[type].apply(
 		oa, [val, {}, selector]
 	    );
 	    $(container).empty().append(toinsert.contents());
 	    selector.remove();
-	}
-	if (type === "text/latex" && MathJax) {
-	    MathJax.Hub.Queue(["Typeset", MathJax.Hub, toinsert.get(0)]);
 	}
     }
 

--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -197,7 +197,7 @@ end
 
 const widget_comms = Dict{Widget, Comm}()
 function update_view(w::Widget; prevw=w)
-    if typeof(w) != typeof(prevw)
+    if typeof(w) != typeof(prevw) || (isa(w, Box) && (w.vert != prevw.vert))
         #If the widget type has changed, a new widget must be set up and the old
         #one removed.
         remove_view(prevw)
@@ -207,6 +207,7 @@ function update_view(w::Widget; prevw=w)
         if w !== prevw
             #new widget instance takes over the comm of the old instnace
             wire_comms(w, widget_comms[prevw])
+            isa(w, Box) && (w.layout = prevw.layout)
             delete!(widget_comms, prevw)
         end
         #update all existing views of the widget

--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -45,7 +45,7 @@ function get_data_dict(value, mimetypes)
             dict[string("text/latex")] =
                 stringmime("application/x-latex", value)
         else
-            warn("IPython seems to be requesting an unavailable mime type")
+            warn("IPython seems to be requesting an unavailable mime type: $m, value: ", string(value))
         end
     end
     return dict

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -46,13 +46,16 @@ function error_handler(sig, value, err)
     Reactive.print_error(sig, value, err, open("/tmp/Interact.log", "a"))
 end
 
-function recv_msg{T}(widget ::InputWidget{T}, value)
+function recv_msg{T}(widget::InputWidget{T}, val)
     # Hand-off received value to the signal graph
-    parsed = parse_msg(widget, value)
-    #println(STDERR, signal(widget))
-    push!(signal(widget), parsed)
+    parsed = parse_msg(widget, val)
     widget.value = parsed
-    if value != parsed
+    if signal(widget).value != parsed || isa(widget, Button)
+        #push only changed values, but for Buttons we always push
+        push!(signal(widget), parsed)
+    end
+    if val != parsed
+        println(STDERR, "val != parsed: <val>$val</val> <parsed>$parsed</parsed>")
         update_view(widget)
     end
 end

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -1,9 +1,9 @@
 import Base: convert, haskey, setindex!, getindex
-export slider, togglebutton, button,
+export slider, vslider, togglebutton, button,
        checkbox, textbox, textarea,
        radiobuttons, dropdown, selection,
        togglebuttons, html, latex, hbox, vbox,
-       progress, widget, selection_slider,
+       progress, widget, selection_slider, vselection_slider,
        set!
 
 const Empty = VERSION < v"0.4.0-dev" ? Nothing : Void
@@ -98,6 +98,13 @@ slider{T}(range::Range{T};
     end
     s
 end
+
+"""
+`vslider(args...; kwargs...)`
+
+Shorthand for `slider(args...; orientation="vertical", kwargs...)`
+"""
+vslider(args...; kwargs...) = slider(args...; orientation="vertical", kwargs...)
 
 ######################### Checkbox ###########################
 
@@ -420,11 +427,18 @@ signal value is found in the range/choice, use `syncnearest=false`.
 selection_slider(opts; kwargs...) = begin
     if !haskey(Dict(kwargs), :value_label)
         #default to middle of slider
-        mid_idx = length(opts)÷2 + 1 # +1 to round up.
+        mid_idx = length(opts)÷2
         push!(kwargs, (:sel_mid_idx, mid_idx))
     end
     Options(:SelectionSlider, opts; kwargs...)
 end
+
+"""
+`vselection_slider(args...; kwargs...)`
+
+Shorthand for `selection_slider(args...; orientation="vertical", kwargs...)`
+"""
+vselection_slider(args...; kwargs...) = selection_slider(args...; orientation="vertical", kwargs...)
 
 function nearest_val(x, val)
     local valbest

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -321,7 +321,11 @@ Options(view::Symbol, options::OptionDict;
         syncselnearest = view == :SelectionSlider && typ <: Real && syncnearest
         if view != :SelectMultiple
             #set up map that keeps the value_label in sync with the value
-            #TODO handle SelectMultiple. Need something similar to handle_msg
+            #TODO handle SelectMultiple. Need something similar to handle_msg,
+            #note also ow.value_label is an AbstractString whereas for SelectMultiple
+            #it should be a Vector{AbstractString} so would want to have Tvalue and
+            #Tlabel type parameters. Also would need to set w.value_label in handle_msg
+            #to avoid multiple updating
             keep_label_updated(val) = begin
                 if syncselnearest
                     val = nearest_val(keys(ow.options.invdict), val)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -494,7 +494,7 @@ widget instances/views.
 If `fld` is `:value`, `val` is also `push!`ed to `signal(w)`
 """
 function set!(w::Widget, fld::Symbol, val)
-    fld == :value && push!(signal(w), val)
+    fld == :value && val != signal(w).value && push!(signal(w), val)
     setfield!(w, fld, val)
     update_view(w)
     w

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -393,8 +393,10 @@ selection: see the help for `dropdown`
 """
 function selection(opts; multi=false, kwargs...)
     if multi
-        signal = Signal(collect(opts)[1:1])
-        Options(:SelectMultiple, opts; signal=signal, kwargs...)
+        options = getoptions(opts)
+        #signal needs to be of an array of values, not just a single value
+        signal = Signal(collect(values(options))[1:1])
+        Options(:SelectMultiple, options; signal=signal, kwargs...)
     else
         Options(:Select, opts; kwargs...)
     end

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -144,7 +144,7 @@
    "outputs": [],
    "source": [
     "#Slider options: vertical, no readout \n",
-    "s1 = slider(-1:.05:1, value=sin(2), label=\"vert\", orientation=\"vertical\")\n",
+    "s1 = vslider(-1:.05:1, value=sin(2), label=\"vert\")\n",
     "s2 = slider(-1:.05:1, value=sin(2), label=\"no readout\", signal=signal(s1), orientation=\"horizontal\", readout=false)\n",
     "display.([s1,s2]);"
    ]

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -41,9 +41,10 @@
    "outputs": [],
    "source": [
     "#Dependent sliders\n",
-    "# first and second numbers (signal(first_slider) and sval) should update if you move the sin slider (before moving x)\n",
-    "# but shouldn't update after you move the x slider\n",
-    "# second two (sval and cval) should update always\n",
+    "# move the sin slider (before moving x): the first number below the widgets (signal(first_slider)) \n",
+    "# should update, but should stop after you move the x slider\n",
+    "# second and third (sval and cval) should update if x is moved, and if sin or cos slider is moved respectively\n",
+    "# moving the x should also move the sliders\n",
     "\n",
     "x = slider(0:.1:2pi, label=\"x\")\n",
     "s = map(a -> slider(-1:.05:1, value=sin(2a), label=\"sin(2x)\"), signal(x))\n",
@@ -247,7 +248,7 @@
    },
    "outputs": [],
    "source": [
-    "# Same but vertical selection_slider, Float64 checkbox, shared signal, and textbox value set.\n",
+    "# Same but vertical selection_slider, Float64 textbox, shared signal, and textbox value set.\n",
     "# Value should be the value from the textbox, changes in slider should update the textbox and vice-versa \n",
     "\n",
     "expslide = selection_slider(2.^(1:0.01:10), label=\"exponential value\"; orientation=\"vertical\")\n",
@@ -281,6 +282,7 @@
    },
    "outputs": [],
    "source": [
+    "#single select\n",
     "ss = selection(11:20)\n",
     "display.([ss,signal(ss)]);"
    ]
@@ -423,10 +425,10 @@
    },
    "outputs": [],
    "source": [
-    "#layout\n",
+    "#layout hbox vbox\n",
     "cb = checkbox();\n",
     "s1 = slider(1:10; orientation=\"vertical\"); \n",
-    "s2 = slider(11:0.1:20; orientation=\"vertical\"); \n",
+    "s2 = vslider(11:0.1:20; label=\"s2\"); \n",
     "layout = hbox(vbox(s1,cb), s2)\n",
     "display.([layout, map(signal, (cb,s1,s2))...]);"
    ]
@@ -435,12 +437,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "#hbox, vbox as values of a signal{Widget} 1\n",
-    "\n",
+    "# Sets of togglebuttons should appear on one row, as you move the slider\n",
     "n = selection_slider(1:4)\n",
     "s1 = map(nv->hbox(map(nvi->togglebuttons(nvi+10:nvi+13), 1:nv)...), signal(n))\n",
     "display.([n, s1]);"
@@ -450,11 +452,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "#hbox, vbox as values of a signal{Widget} 1, orientation should change from horizontal to vertical\n",
+    "# hbox, vbox as values of a signal{Widget} 1, orientation should change from horizontal to\n",
+    "# vertical as you move the slider\n",
     "\n",
     "s2 = map(nv->(boxer = nv%2 == 0 ? hbox : vbox; boxer(togglebuttons(nv:nv+3), togglebuttons(nv:nv+3))), signal(n))\n",
     "display.([n, s2]);"
@@ -484,6 +487,7 @@
    },
    "outputs": [],
    "source": [
+    "# test the set! function, bottom slider should have the range defined by the top 3 sliders\n",
     "sldmin = slider(0:.01:10.0, label=\"min value\")\n",
     "sldstep = slider(0.01:.01:1, label=\"step size\")\n",
     "sldmax = slider(10.0:.1:20.0, label=\"max value\")\n",
@@ -497,11 +501,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "#latex output, should be replaced and formatted nicely\n",
+    "#latex output, should be replaced and formatted nicely as you ramp up the slider\n",
+    "using SymPy\n",
     "x=Sym(\"x\")\n",
     "s = @manipulate for n=vslider(1:50)\n",
     "    SymPy.diff(sin(x^2),x,n)\n",
@@ -534,6 +539,15 @@
     "display(s5)\n",
     "foreach(v ->(@show v), signal(s5));"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -267,8 +267,10 @@
     "# multi-select - ctrl/cmd or shift click for multiple values\n",
     "mse = selection(enumerate([\"fred\",2,1 + 0.5im, 0.3]) |> collect, multi=true)\n",
     "ms = selection([\"fred\",2,1 + 0.5im, 0.3], multi=true)\n",
+    "abc = selection([(\"a\",1), (\"b\",2), (\"c\",3)]; multi=true)\n",
     "display.([ms,signal(ms)]);\n",
-    "# display.([mse,signal(mse)]); Currently broken, should work;"
+    "display.([mse,signal(mse)]);\n",
+    "display.([abc,signal(abc)]);"
    ]
   },
   {

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -500,7 +500,26 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "#latex output, should be replaced and formatted nicely\n",
+    "x=Sym(\"x\")\n",
+    "s = @manipulate for n=vslider(1:50)\n",
+    "    SymPy.diff(sin(x^2),x,n)\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#make sure the default options index is not 0, i.e. this shouldn't error\n",
+    "selection_slider(-1:-1)"
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": null,

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -501,6 +501,20 @@
    },
    "outputs": [],
    "source": []
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#first click on slider shouldn't show output, only subsequent moves.\n",
+    "#i.e. output should be v=3 (initial), then v=4 or v=2 after moving the slider left or right\n",
+    "s5 = slider(1:5)\n",
+    "display(s5)\n",
+    "foreach(v ->(@show v), signal(s5));"
+   ]
   }
  ],
  "metadata": {

--- a/test/notebooks/Interact Manual Tests.ipynb
+++ b/test/notebooks/Interact Manual Tests.ipynb
@@ -433,6 +433,35 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#hbox, vbox as values of a signal{Widget} 1\n",
+    "\n",
+    "n = selection_slider(1:4)\n",
+    "s1 = map(nv->hbox(map(nvi->togglebuttons(nvi+10:nvi+13), 1:nv)...), signal(n))\n",
+    "display.([n, s1]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#hbox, vbox as values of a signal{Widget} 1, orientation should change from horizontal to vertical\n",
+    "\n",
+    "s2 = map(nv->(boxer = nv%2 == 0 ? hbox : vbox; boxer(togglebuttons(nv:nv+3), togglebuttons(nv:nv+3))), signal(n))\n",
+    "display.([n, s2]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "collapsed": false
    },
    "outputs": [],


### PR DESCRIPTION
A few different fixes, see the commit messages for more details.

Also adds `vslider` and `vselection_slider`

I think it would be good to tag another release with these, the first commit is especially important since a `@manipulate` slider can behave weirdly without it - especially if the kernel is remote.

Commit 6 fixes #146 and the minor issue remaining in #144 (with the use of LaTeXStrings.jl)