### PR TITLE
Fix travis build and enable precompilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ os:
   - osx
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - julia: nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 JSON 0.7
 Compat 0.8.0
-Reactive 0.3
+Reactive 0.3.7
 DataStructures 0.2.10

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module Interact
 
 using Reactive, Compat, DataStructures


### PR DESCRIPTION
This turns on Travis builds for julia v0.5 and allows Travis to fail on v0.6 (in which there are currently IJulia build errors unrelated to this package). 

It also enables precompilation now that Reactive v0.3.7 has been tagged. 