### PR TITLE
fix tests on julia v0.6-dev

### DIFF
--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -3,17 +3,16 @@ using Reactive
 using Compat
 import Compat.String
 
-import Base: writemime
 import Interact: update_view, Slider, Widget, InputWidget, Latex, HTML, recv_msg,
                  statedict, viewdict, Layout, Box,
                  Progress, Checkbox, Button, ToggleButton, Textarea, Textbox, Options
 
-export mimewritable, writemime
+export mimewritable 
 
 const ijulia_js = readstring(joinpath(dirname(@__FILE__), "ijulia.js"))
 
 if displayable("text/html")
-    display("text/html", """
+    display("text/html", Base.Docs.HTML("""
      <div id="interact-js-shim">
          <script charset="utf-8">$(ijulia_js)</script>
          <script>
@@ -25,7 +24,7 @@ if displayable("text/html")
             })
             \$([IPython.events]).on("kernel_starting.Kernel kernel_restarting.Kernel", function () { window.interactLoadedFlag = false })
         </script>
-     </div>""")
+     </div>"""))
 end
 
 import IJulia
@@ -54,7 +53,7 @@ end
 function init_comm(x::Signal)
     if !haskey(comms, x)
         subscriptions = Dict{Compat.ASCIIString, Int}()
-        function handle_subscriptions(msg)
+        handle_subscriptions = (msg) -> begin
             if haskey(msg.content, "data")
                 action = get(msg.content["data"], "action", "")
                 if action == "subscribe_mime"
@@ -72,7 +71,7 @@ function init_comm(x::Signal)
         # Listen for mime type registrations
         comm.on_msg = handle_subscriptions
         # prevent resending the first time?
-        function notify(value)
+        notify = (value) -> begin
             mimes = keys(filter((k,v) -> v > 0, subscriptions))
             if length(mimes) > 0
                 send_comm(comm, @compat Dict(:value =>

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -4,7 +4,7 @@ module Interact
 
 using Reactive, Compat, DataStructures
 
-import Base: mimewritable, writemime
+import Base: mimewritable
 export signal, Widget, InputWidget
 
 # A widget

--- a/test/ijulia.jl
+++ b/test/ijulia.jl
@@ -18,7 +18,11 @@ include(Interact.ijulia_setup_path)
 sliderWidget = slider(1:5)
 @testset "ijulia.jl" begin
 
-    @test """Interact.Slider{Int64}(Signal{Int64}(3, nactions=1),\"\",3,1:5,\"horizontal\",true,\"d\",true)""" == stringmime("text/plain", sliderWidget)
+    removespaces(s) = replace(s, " ", "")
+    # Julia v0.6 uses spaces after commas when printing types, but
+    # previous versions did not. To ensure that this test works on all
+    # versions, we just remove spaces from both sides of the comparison.
+    @test removespaces("""Interact.Slider{Int64}(Signal{Int64}(3, nactions=1),\"\",3,1:5,\"horizontal\",true,\"d\",true)""") == removespaces(stringmime("text/plain", sliderWidget))
     @test "3" == stringmime("text/plain", signal(sliderWidget))
 
     @test "" == stringmime("text/html", sliderWidget)


### PR DESCRIPTION
This brings in enough updates to ensure that the unit tests pass on Julia v0.6-dev. I'm still having issues with actually *using* Interact in v0.6, but I think this is at least a step in the right direction. 

With this update, I can execute an `@manipulate` cell in a notebook without errors, but the output of the cell does not update as I move the slider. I don't understand enough about the way IJulia actually works to be able to fix that yet. 

One other note: this converts the nested functions in `IJulia/setup.jl` to anonymous closures to avoid world-age problems. That will hurt performance on Julia v0.4, so if you do go with this method, it might be worth bumping the julia requirement to v0.5 for these changes. 