### PR TITLE
fix @manipulate hygiene and add a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -16,7 +16,7 @@ end
 function map_block(block, symbols)
     lambda = Expr(:(->), Expr(:tuple, symbols...),
                   block)
-    :(preserve(map($lambda, $(map(s->:(signal($s)), symbols)...), typ=Any)))
+    :(preserve(map($(esc(lambda)), $(map(s->:(signal($s)), esc.(symbols))...), typ=Any)))
 end
 
 function symbols(bindings)
@@ -37,6 +37,6 @@ macro manipulate(expr)
     syms = symbols(bindings)
     Expr(:let, Expr(:block,
                     display_widgets(syms)...,
-                    esc(map_block(block, syms))),
+                    map_block(block, syms)),
          map(make_widget, bindings)...)
 end

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -23,6 +23,13 @@ function symbols(bindings)
     map(x->x.args[1], bindings)
 end
 
+@static if VERSION >= v"0.7.0-DEV.1671"
+    make_let_block(declarations, statements) = Expr(:let, declarations, statements)
+else
+    make_let_block(declarations, statements) = Expr(:let, statements, declarations)
+end
+
+
 macro manipulate(expr)
     if expr.head != :for
         error("@manipulate syntax is @manipulate for ",
@@ -35,8 +42,9 @@ macro manipulate(expr)
         bindings = [expr.args[1]]
     end
     syms = symbols(bindings)
-    Expr(:let, Expr(:block,
-                    display_widgets(syms)...,
-                    map_block(block, syms)),
-         map(make_widget, bindings)...)
+    declarations = Expr(:block, map(make_widget, bindings)...)
+    statements = Expr(:block,
+                      display_widgets(syms)...,
+                      map_block(block, syms)) 
+    make_let_block(declarations, statements)
 end

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -16,7 +16,7 @@ end
 function map_block(block, symbols)
     lambda = Expr(:(->), Expr(:tuple, symbols...),
                   block)
-    :(preserve(map($(esc(lambda)), $(map(s->:(signal($s)), esc.(symbols))...), typ=Any)))
+    :($preserve(map($(lambda), $(map(s->:($signal($s)), symbols)...), typ=Any)))
 end
 
 function symbols(bindings)
@@ -37,6 +37,6 @@ macro manipulate(expr)
     syms = symbols(bindings)
     Expr(:let, Expr(:block,
                     display_widgets(syms)...,
-                    map_block(block, syms)),
+                    esc(map_block(block, syms))),
          map(make_widget, bindings)...)
 end

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -23,6 +23,11 @@ function symbols(bindings)
     map(x->x.args[1], bindings)
 end
 
+"""
+Work-around for the fact that the order of arguments in `let...end` parsing
+was reversed from v0.6 to v0.7. 
+See: https://github.com/JuliaLang/julia/issues/21774
+"""
 @static if VERSION >= v"0.7.0-DEV.1671"
     function make_let_block(declarations, statements)
         Expr(:let, Expr(:block, declarations...), Expr(:block, statements...))

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -24,9 +24,13 @@ function symbols(bindings)
 end
 
 @static if VERSION >= v"0.7.0-DEV.1671"
-    make_let_block(declarations, statements) = Expr(:let, declarations, statements)
+    function make_let_block(declarations, statements)
+        Expr(:let, Expr(:block, declarations...), Expr(:block, statements...))
+    end
 else
-    make_let_block(declarations, statements) = Expr(:let, statements, declarations)
+    function make_let_block(declarations, statements)
+        Expr(:let, Expr(:block, statements...), declarations...)
+    end
 end
 
 
@@ -42,9 +46,8 @@ macro manipulate(expr)
         bindings = [expr.args[1]]
     end
     syms = symbols(bindings)
-    declarations = Expr(:block, map(make_widget, bindings)...)
-    statements = Expr(:block,
-                      display_widgets(syms)...,
-                      map_block(block, syms)) 
+    declarations = map(make_widget, bindings)
+    statements = vcat(display_widgets(syms)...,
+                      map_block(block, syms))
     make_let_block(declarations, statements)
 end

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -16,7 +16,7 @@ end
 function map_block(block, symbols)
     lambda = Expr(:(->), Expr(:tuple, symbols...),
                   block)
-    :($preserve(map($(lambda), $(map(s->:($signal($s)), symbols)...), typ=Any)))
+    :(preserve(map($(esc(lambda)), $(map(s->:(signal($s)), esc.(symbols))...), typ=Any)))
 end
 
 function symbols(bindings)
@@ -37,6 +37,6 @@ macro manipulate(expr)
     syms = symbols(bindings)
     Expr(:let, Expr(:block,
                     display_widgets(syms)...,
-                    esc(map_block(block, syms))),
+                    map_block(block, syms)),
          map(make_widget, bindings)...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,18 @@ module HygieneTest
         i, j
     end
 end
+
+module HygieneTest2
+    # Verify that `@manipulate` is really using Reactive.signal
+    # and Reactive.preserve, not whatever the user has defined
+
+    using Interact: @manipulate
+
+    # Dummy implementations that should never be called:
+    signal(x...) = error("I should not be called")
+    preserve(x...) = error("I should not be called")
+
+    @manipulate for i in 1:10, j in ["x", "y", "z"]
+        2 * i, j * " hello"
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,14 @@ using Base.Test
 
 include("widgets.jl")
 include("ijulia.jl")
+
+module HygieneTest
+    # Test that the `@manipulate` macro does not rely on
+    # any symbols from other packages (like Reactive or Interact)
+    # being defined in the user's current namespace
+    using Interact: @manipulate
+
+    @manipulate for i in 1:10, j in ["x", "y", "z"]
+        i, j
+    end
+end


### PR DESCRIPTION
`@manipulate` was escaping too many things, which meant that it relied on the user having done `using Interact` and `using Reactive`. This change removes that requirement, and will also prevent weird errors in the case that a user has some local function called `signal` or `preserve`. 

Fixes #184 
Also fixes #156
