### PR TITLE
isolate the IJulia setup inside a module

### DIFF
--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -1,5 +1,8 @@
+module InteractIJulia
+
 using JSON
 using Reactive
+using Interact
 using Compat
 import Compat.String
 
@@ -316,3 +319,5 @@ end
 
 include("statedict.jl")
 include("handle_msg.jl")
+
+end

--- a/src/IJulia/setup_old.jl
+++ b/src/IJulia/setup_old.jl
@@ -1,6 +1,9 @@
+module InteractIJulia
+
 using JSON
 using Reactive
 using Compat
+using Interact
 import Compat.String
 
 import Interact: update_view, Slider, Widget, InputWidget, Latex, HTML, recv_msg,
@@ -307,3 +310,5 @@ end
 
 include("statedict_old.jl")
 include("handle_msg_old.jl")
+
+end


### PR DESCRIPTION
fixes #186 by wrapping the `setup.jl` code in a module. This is necessary because when Interact does:

```
function __init__()
  include("setup.jl")
end
```

`setup.jl` is executed in the user's current workspace, not inside the Interact module, which causes clashes with user-defined functions.

@JobJob can you verify that this fixes the issue for you? 

I think an alternative to this would be to do `eval(Interact, parse(<text of setup.jl>))` which might be even better, but I haven't tried that yet. 

