### PR TITLE
Make building work for Windows when ENV["PYTHON"] exists

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,10 +11,10 @@ function main()
     if is_linux() || is_apple()
         python = strip(readline(readstring(`which $(IJulia.jupyter)`)|>strip), ['\n',' ', '#','!'])
     elseif is_windows()
-        if haskey(ENV,"PYTHON")
+        if haskey(ENV,"PYTHON") && ENV["PYTHON"] != ""
             python = ENV["PYTHON"]
         else
-            warn("cannot determine jupyter's python path in Windows, bailing.")
+            warn("Cannot determine jupyter's python path in Windows, bailing. Please add the path to python.exe, e.g. path/to/python.exe, to ENV["PYTHON"].")
             return
         end
     end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,8 +11,12 @@ function main()
     if is_linux() || is_apple()
         python = strip(readline(readstring(`which $(IJulia.jupyter)`)|>strip), ['\n',' ', '#','!'])
     elseif is_windows()
-        warn("cannot determine jupyter's python path in Windows, bailing.")
-        return
+        if haskey(ENV,"PYTHON")
+            python = ENV["PYTHON"]
+        else
+            warn("cannot determine jupyter's python path in Windows, bailing.")
+            return
+        end
     end
 
     try


### PR DESCRIPTION
I modified build.jl to use ENV["PYTHON"] on Windows when defined.