### PR TITLE
Add continuous_update keyword for option widgets and fix a bunch of ipywidget 7 related bugs.

### DIFF
--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -157,7 +157,7 @@ JSON.lower(s::Signal) = s.value
 # Interact -> IJulia view names
 widget_class(::HTML) = "HTML"
 widget_class(::Layout) = "Layout"
-widget_class(::Box) = "Box"
+widget_class(b::Box) = b.vert ? "VBox" : "Box"
 widget_class(::Latex) = "Label"
 widget_class(::Progress) = "Progress"
 widget_class{T<:Integer}(::Slider{T}) = "IntSlider"

--- a/src/IJulia/statedict.jl
+++ b/src/IJulia/statedict.jl
@@ -47,6 +47,7 @@ statedict{view, T}(d::Options{view, T}) =
          :icons=>d.icons,
          :tooltips=>d.tooltips,
          :readout => d.readout,
+         :continuous_update=>d.continuous_update,
          :_options_labels=>collect(keys(d.options)))
 
 statedict(w::Widget) = begin

--- a/src/IJulia/statedict.jl
+++ b/src/IJulia/statedict.jl
@@ -18,6 +18,7 @@ end
          :_model_name => "FloatSliderModel",
          :readout => s.readout,
          :readout_format => s.readout_format,
+         :orientation => s.orientation,
          :continuous_update=>s.continuous_update,
      )
 
@@ -48,6 +49,7 @@ statedict{view, T}(d::Options{view, T}) =
          :tooltips=>d.tooltips,
          :readout => d.readout,
          :continuous_update=>d.continuous_update,
+         :orientation => d.orientation,
          :_options_labels=>collect(keys(d.options)))
 
 statedict(w::Widget) = begin

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -303,6 +303,7 @@ type Options{view, T} <: InputWidget{T}
     tooltips::AbstractArray
     readout::Bool
     orientation::AbstractString
+    continuous_update::Bool
 end
 
 labels2idxs(d::OptionDict, labels) = findin(keys(d), labels)
@@ -320,13 +321,14 @@ Options(view::Symbol, options::OptionDict;
         orientation="horizontal",
         syncsig=true,
         syncnearest=true,
+        continuous_update=true,
         sel_mid_idx=0) = begin
     #sel_mid_idx set in selection_slider(...) so default value_label is middle of range
     sel_mid_idx != 0 && (value_label = collect(keys(options.dict))[sel_mid_idx])
     signal, value = init_wsigval(signal, value; typ=typ, default=options[value_label])
     typ = eltype(signal)
     ow = Options{view, typ}(signal, label, value, value_label, index,
-                    options, icons, tooltips, readout, orientation)
+                    options, icons, tooltips, readout, orientation, continuous_update)
     if syncsig
         syncselnearest = view == :SelectionSlider && typ <: Real && syncnearest
         if view != :SelectMultiple

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -364,7 +364,7 @@ function Options(view::Symbol,
 end
 
 function getoptions(options)
-    opts = OrderedDict()
+    opts = OrderedDict{String, eltype(options)}()
     for el in options
         addoption!(opts, el)
     end

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -342,8 +342,7 @@ Options(view::Symbol, options::OptionDict;
                 if syncselnearest
                     val = nearest_val(keys(ow.options.invdict), val)
                 end
-                if haskey(ow.options.invdict, val) &&
-                  ow.value_label != ow.options.invdict[val]
+                if haskey(ow.options.invdict, val)
                     ow.value_label = ow.options.invdict[val]
                     ow.index = labels2idxs(ow.options, [ow.value_label]) |> first
                     update_view(ow)


### PR DESCRIPTION
This minor update adds the kwarg continuous_update=Bool (true by default) to the option widgets. 

My motivation for this was to allow non-continuous updates of selection_sliders.