### PR TITLE
try harder to find Jupyter and Python during build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -28,7 +28,7 @@ function main()
         if endswith(IJulia.notebook_cmd[1], "python.exe")
             python = IJulia.notebook_cmd[1]
         elseif startswith(IJulia.jupyter, Pkg.dir("Conda")) # using the Conda Python
-            python = eval(Main, :(using Conda; Conda.PYTHONDIR)) * ".exe"
+            python = joinpath(eval(Main, :(using Conda; Conda.PYTHONDIR)), "python.exe")
         elseif haskey(ENV,"PYTHON") && !isempty(ENV["PYTHON"])
             python = ENV["PYTHON"]
         else


### PR DESCRIPTION
This PR tries harder to correctly configure Interact on Windows.

On Windows, running `jupyter` subcommands can be tricky because of JuliaLang/IJulia.jl#363.   I had to reproduce some of the logic from the IJulia build script here.

Also, it tries a bit harder on Windows to find `python.exe`, especially for Conda builds.

This also fixes the issue with `@PYTHON_str` mentioned in #205.