### PR TITLE
Progress meter fixes

### DIFF
--- a/src/IJulia/setup.jl
+++ b/src/IJulia/setup.jl
@@ -159,7 +159,7 @@ widget_class(::HTML) = "HTML"
 widget_class(::Layout) = "Layout"
 widget_class(b::Box) = b.vert ? "VBox" : "Box"
 widget_class(::Latex) = "Label"
-widget_class(::Progress) = "Progress"
+widget_class(::Progress) = "FloatProgress"
 widget_class{T<:Integer}(::Slider{T}) = "IntSlider"
 widget_class(::Button) = "Button"
 widget_class(::Textarea) = "Textarea"
@@ -174,13 +174,8 @@ widget_class(w, suffix) = widget_class(w) * suffix
 view_name(w) = widget_class(w, "View")
 model_name(w) = widget_class(w, "Model")
 
-"""
-Update output widgets
-"""
-update!(p::Progress, val) = begin
-    p.value = val;
-    update_view(p)
-end
+# Special cases
+view_name(w::Progress) = "ProgressView"
 
 function metadata(x::Widget)
     display_widget(x)

--- a/src/IJulia/setup_old.jl
+++ b/src/IJulia/setup_old.jl
@@ -10,7 +10,7 @@ import Interact: update_view, Slider, Widget, InputWidget, Latex, HTML, recv_msg
                  statedict, viewdict, Layout, Box,
                  Progress, Checkbox, Button, ToggleButton, Textarea, Textbox, Options
 
-export mimewritable 
+export mimewritable
 
 const ijulia_js = readstring(joinpath(dirname(@__FILE__), "ijulia.js"))
 
@@ -173,14 +173,6 @@ widget_class{view}(::Options{view}) = string(view)
 widget_class(w, suffix) = widget_class(w) * suffix
 view_name(w) = widget_class(w, "View")
 model_name(w) = widget_class(w, "Model")
-
-"""
-Update output widgets
-"""
-update!(p::Progress, val) = begin
-    p.value = val;
-    update_view(p)
-end
 
 function metadata(x::Widget)
     display_widget(x)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -4,7 +4,7 @@ export slider, vslider, togglebutton, button,
        radiobuttons, dropdown, selection,
        togglebuttons, html, latex, hbox, vbox,
        progress, widget, selection_slider, vselection_slider,
-       set!
+       set!, update!
 
 ### Layout Widgets
 type Layout <: Widget
@@ -478,7 +478,7 @@ latex(value; label="") = Latex(label, mimewritable("application/x-latex", value)
 
 type Progress <: Widget
     label::AbstractString
-    value::Int
+    value::Float64
     range::Range
     orientation::String
     readout::Bool
@@ -487,9 +487,17 @@ type Progress <: Widget
 end
 
 progress(args...) = Progress(args...)
-progress(;label="", value=0, range=0:100, orientation="horizontal",
+progress(;label="", range=0.0:0.1:100, value=first(range), orientation="horizontal",
             readout=true, readout_format="d", continuous_update=true) =
     Progress(label, value, range, orientation, readout, readout_format, continuous_update)
+
+"""
+Update output widgets
+"""
+function update!(p::Progress, val)
+    p.value = val;
+    update_view(p)
+end
 
 # Make a widget out of a domain
 widget(x::Signal, label="") = x


### PR DESCRIPTION
Fixes Progress meter for nbwidgetsextension version >= 3.0.0
Moved progress meter update! method to the correct location. 
Changed its value's type from Int->Float64

```
using Interact

pbar = progress(range=-5.0:0.1:5.0)
display(pbar);
```
```
update!(pbar,-3.3)
```