### PR TITLE
Fix type inference of option dict. Closes #213.

### DIFF
--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -362,8 +362,10 @@ function Options(view::Symbol,
     Options(view, getoptions(options); kwargs...)
 end
 
+getoptions(options::AbstractArray{<:Union{Pair, Tuple}}) = getoptions(Dict(options))
+
 function getoptions(options)
-    opts = OrderedDict{String, eltype(options)}()
+    opts = OrderedDict{String, eltype(values(options))}()
     for el in options
         addoption!(opts, el)
     end


### PR DESCRIPTION
Fix bug wherein option widgets cannot handle certain input. Closes #213 

This revision was successfully tested on
```julia
using Interact

sliders = [
    selection_slider(["foo"=> false, "bar"=>true]), 
    selection_slider(["foo"=> 1, "bar"=>1.0, "baz"=>"hello"]), 
    selection_slider(Dict("foo"=> 1, "bar"=>1.0, "baz"=>"hello")), 
    selection_slider([1,2,3]), 
    selection_slider([1,"hello",:x, [1,2]]), 
    selection_slider(1:10), 
    selection_slider([("foo", false), ("bar", true)]), 
    selection_slider(2.^(1:0.01:10), label="exponential value"; orientation="vertical"),
    selection(enumerate(["fred",2,1 + 0.5im, 0.3]) |> collect, multi=true), 
    selection([("a",1), ("b",2), ("c",3)]; multi=true),
]

display.(sliders)

map((x...)->display(x), signal.(sliders)...)
```

I have not been able to test on anything but ipywidgets 7