### PR TITLE
Use NBInclude to test notebooks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'ENV["PYTHON"]=""; Pkg.clone(pwd())'
-  - julia -e 'ENV["PYTHON"]=""; cov=(VERSION < v"0.5-" || !is_apple() || VERSION >= v"0.6-"); Pkg.test("Interact"; coverage=cov)'
-    # Note: PYTHON env is to ensure that PyPlot uses Conda.jl's Miniconda distribution instead of system Python.
+  - julia -e 'Pkg.clone(pwd())'
+  - julia -e 'cov=(VERSION < v"0.5-" || !is_apple() || VERSION >= v"0.6-"); Pkg.test("Interact"; coverage=cov)'
 after_success:
   - julia --color=yes -e 'cd(Pkg.dir("Interact")); Pkg.add("Coverage"); using Coverage;
     Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd())'
-  - julia -e 'cov=(VERSION < v"0.5-" || !is_apple() || VERSION >= v"0.6-"); Pkg.test("Interact"; coverage=cov)'
+  - julia -e 'ENV["PYTHON"]=""; Pkg.clone(pwd())'
+  - julia -e 'ENV["PYTHON"]=""; cov=(VERSION < v"0.5-" || !is_apple() || VERSION >= v"0.6-"); Pkg.test("Interact"; coverage=cov)'
+    # Note: PYTHON env is to ensure that PyPlot uses Conda.jl's Miniconda distribution instead of system Python.
 after_success:
   - julia --color=yes -e 'cd(Pkg.dir("Interact")); Pkg.add("Coverage"); using Coverage;
     Coveralls.submit(Coveralls.process_folder())'

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -5,5 +5,3 @@ IJulia
 NBInclude
 Colors
 Compose
-Gadfly
-PyPlot

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -2,3 +2,8 @@ julia 0.4
 Compat 0.8.0
 BaseTestNext
 IJulia
+NBInclude
+Colors
+Compose
+Gadfly
+PyPlot

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,18 +32,20 @@ end
 # Notebooks
 # notebookdirs = [joinpath(@__DIR__, "notebooks"), joinpath(@__DIR__, "..", "doc", "notebooks")]
 notebookdirs = [joinpath(@__DIR__, "..", "doc", "notebooks")] # Interact Manual Tests.ipynb is broken (flatten call)
+excludes = [joinpath(@__DIR__, "..", "doc", "notebooks", "03-Interactive Diagrams and Plots.ipynb")]
 for notebookdir in notebookdirs
     for file in readdir(notebookdir)
+        path = joinpath(notebookdir, file)
+        path in excludes && continue
         name, ext = splitext(file)
-        if lowercase(ext) == ".ipynb"
-            @eval module $(gensym()) # Each notebook is run in its own module
-                using Base.Test
-                using NBInclude
-                @testset "$($name)" begin
-                    nbinclude(joinpath($notebookdir, $file), regex = r"^((?!\#NBSKIP).)*$"s) # Use #NBSKIP in a cell to skip it during tests
-                end
-            end
+        lowercase(ext) == ".ipynb" || continue
+        @eval module $(gensym()) # Each notebook is run in its own module.
+        using Base.Test
+        using NBInclude
+        @testset "$($name)" begin
+            nbinclude($path, regex = r"^((?!\#NBSKIP).)*$"s) # Use #NBSKIP in a cell to skip it during tests.
         end
+        end # module
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,3 +28,22 @@ module HygieneTest2
         2 * i, j * " hello"
     end
 end
+
+# Notebooks
+# notebookdirs = [joinpath(@__DIR__, "notebooks"), joinpath(@__DIR__, "..", "doc", "notebooks")]
+notebookdirs = [joinpath(@__DIR__, "..", "doc", "notebooks")] # Interact Manual Tests.ipynb is broken (flatten call)
+for notebookdir in notebookdirs
+    for file in readdir(notebookdir)
+        name, ext = splitext(file)
+        if lowercase(ext) == ".ipynb"
+            @eval module $(gensym()) # Each notebook is run in its own module
+                using Base.Test
+                using NBInclude
+                @testset "$($name)" begin
+                    nbinclude(joinpath($notebookdir, $file), regex = r"^((?!\#NBSKIP).)*$"s) # Use #NBSKIP in a cell to skip it during tests
+                end
+            end
+        end
+    end
+end
+


### PR DESCRIPTION
Adds lots of test dependencies, but now you're sure that the notebooks will run without error. NBInclude itself is a lightweight package, the other packages are just needed to run the notebooks.

I wanted to do the notebook in `test/notebooks` as well, but it currently doesn't run on my machine due to a call to some nonstandard `flatten` method.

Note that you can skip certain cells by adding `#NBSKIP` to the cell. This can e.g. be useful to eliminate test dependencies that you really only need for one cell.

Another option would be to skip `03-Interactive Diagrams and Plots.ipynb` completely, to get rid of the Gadfly and PyPlot dependencies.