### PR TITLE
Remove nbwidgetsextension info message

### DIFF
--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -104,10 +104,8 @@ function __init__()
             v = v"3.0.0"
         end
         if v >= v"3.0.0"
-            info("Interact.jl: using new nbwidgetsextension protocol")
             include(ijulia_setup_path)
         else
-            info("Interact.jl: using old nbwidgetsextension protocol")
             include(ijulia_setup_path_old)
         end
     end


### PR DESCRIPTION
As a user, I don't really care which nbwidgetsextension protocol is being used as long as things are working. In my opinion, printing this message every time I use Interact is just noise.