### PR TITLE
bump interactbase deps

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.6
 JSON 0.7
 Compat 0.17
-InteractBase 0.2.0
-InteractBulma
-InteractUIkit
+InteractBase 0.3.0
+InteractBulma 0.2.0
+InteractUIkit 0.2.0
 DataStructures 0.2.10


### PR DESCRIPTION
The new tag of the Interact* set of packages was just merged in METADATA and this ensures that Interact gets the fully featured version (InteractBase 0.2 was still missing some features)