### PR TITLE
Reexport JuliaGizmos packages and unify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Interact
 
 [![Build Status](https://travis-ci.org/JuliaGizmos/Interact.jl.svg?branch=master)](https://travis-ci.org/JuliaGizmos/Interact.jl)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaGizmos.github.io/Interact.jl/latest)
 
 Interact.jl allows you to use interactive widgets such as sliders, dropdowns and checkboxes to play with your Julia code:
 

--- a/doc/notebooks/01-Introduction.ipynb
+++ b/doc/notebooks/01-Introduction.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Interact, CSSUtil, Observables, WebIO\n",
+    "using Interact\n",
     "settheme!(:bulma)"
    ]
   },

--- a/doc/notebooks/02-Widgets Overview.ipynb
+++ b/doc/notebooks/02-Widgets Overview.ipynb
@@ -215,14 +215,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "map(g -> g(e, π*im), signal(f))"
+    "map(g -> \"e $g π*im\", observe(f))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that the order \"Add\", \"Sub\", \"Exp\" was not retained in the above example, because a `Dict` does not save the ordering. To overcome this, we can use `OrderedDict` from DataStructures.jl package."
+    "Notice that the order \"Add\", \"Sub\", \"Exp\" was not retained in the above example, because a `Dict` does not save the ordering. To overcome this, we can use `OrderedDict`:"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f_ = togglebuttons([(\"Add\", +), (\"Sub\", -), (\"Exp\", ^)])"
+    "f_ = togglebuttons(OrderedDict(\"Add\" => +, \"Sub\" => -, \"Exp\" => ^))"
    ]
   },
   {
@@ -240,7 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "map(g -> g(e, π*im), signal(f_))"
+    "map(g -> g(e, π*im), observe(f_))"
    ]
   },
   {
@@ -279,7 +279,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use `spinbox` for number input:"
+    "## Spinbox\n",
+    "\n",
+    "Use spinbox for number input:"
    ]
   },
   {
@@ -288,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "int_box = spinbox(0)"
+    "int_box = spinbox(value=0)"
    ]
   },
   {
@@ -304,7 +306,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If creating a number typed textbox, you can also pass along an optional `range` field to set a bound on the possible values one can input. If an entered value exceeds the range, it is replaced by its nearest bounding number."
+    "If creating a number typed textbox, you can also pass along an optional `range` field to set a bound on the possible values one can input."
    ]
   },
   {
@@ -313,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bounded_float_box = textbox(2pi, range=-10.0:10)"
+    "bounded_float_box = spinbox(-10.0:10)"
    ]
   },
   {
@@ -322,7 +324,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "signal(bounded_float_box)"
+    "observe(bounded_float_box)"
    ]
   },
   {
@@ -345,7 +347,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tex = textarea(\"Your very own \\$\\\\LaTeX\\$ editor\")"
+    "tex = textarea(\"Your very own textarea\")"
    ]
   },
   {
@@ -354,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "map(latex, signal(tex))"
+    "map(latex, observe(tex))"
    ]
   },
   {
@@ -386,6 +388,13 @@
     "    widget(Dict(:π => float(π), :τ => 2π))\n",
     "    ]);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/doc/notebooks/02-Widgets Overview.ipynb
+++ b/doc/notebooks/02-Widgets Overview.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Interact, WebIO\n",
+    "using Interact\n",
     "settheme!(:bulma)"
    ]
   },

--- a/doc/notebooks/02-Widgets Overview.ipynb
+++ b/doc/notebooks/02-Widgets Overview.ipynb
@@ -338,7 +338,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`textarea` takes an optional default value and creates a textarea. Its signal changes when you type."
+    "`textarea` takes an optional default value and creates a textarea. Its `Observable` changes when you type."
    ]
   },
   {
@@ -347,7 +347,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tex = textarea(\"Your very own textarea\")"
+    "tex = textarea(value=\"\\\\sum_{i=1}^{\\\\infty} e_i\")"
    ]
   },
   {

--- a/doc/notebooks/03-Interactive Diagrams and Plots.ipynb
+++ b/doc/notebooks/03-Interactive Diagrams and Plots.ipynb
@@ -34,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[WebIO](https://github.com/JuliaGizmos/WebIO.jl) allows us to create any element in the DOM, such as for example svg. Here is an example compose diagram you can play around with."
+    "The `dom\"..\"` macro allows us to create any element in the DOM, such as for example svg. Here is an example you can play around with."
    ]
   },
   {
@@ -45,7 +45,6 @@
    },
    "outputs": [],
    "source": [
-    "using WebIO\n",
     "width, height = 700, 300\n",
     "colors = [\"black\", \"gray\", \"silver\", \"maroon\", \"red\", \"olive\", \"yellow\", \"green\", \"lime\", \"teal\", \"aqua\", \"navy\", \"blue\", \"purple\", \"fuchsia\"]\n",
     "color(i) = colors[i%length(colors)+1]\n",

--- a/doc/notebooks/04-Animations.ipynb
+++ b/doc/notebooks/04-Animations.ipynb
@@ -20,14 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is possible to create interactive animations using Reactive's [timing functions](julialang.org/Reactive.jl/api.html#timing)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Functions like `fps`, `fpswhen`, `every` etc, let us create periodically updating signals. This, combined with the other functions in Reactive provide for declarative ways to define animations. Let us now take the n-gon compose example from interactive diagrams notebook and animate it."
+    "It is possible to create interactive animations using `@async` to create asyncronous timers"
    ]
   },
   {

--- a/doc/notebooks/04-Animations.ipynb
+++ b/doc/notebooks/04-Animations.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Interact, Observables, WebIO, Plots"
+    "using Interact, Plots"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Plots, Interact, Colors"
+    "using Plots, Colors"
    ]
   },
   {

--- a/doc/notebooks/tutorial.ipynb
+++ b/doc/notebooks/tutorial.ipynb
@@ -90,7 +90,7 @@
    "cell_type": "code",
    "source": [
     "using Mux\n",
-    "webio_serve(page(\"/\", req -> ui), rand(8000:9000)) # serve on a random port"
+    "WebIO.webio_serve(page(\"/\", req -> ui), rand(8000:9000)) # serve on a random port"
    ],
    "metadata": {},
    "execution_count": null

--- a/doc/notebooks/tutorial.ipynb
+++ b/doc/notebooks/tutorial.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "using Interact, WebIO\n",
+    "using Interact\n",
     "ui = button()\n",
     "display(ui)"
    ],
@@ -241,7 +241,6 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "using DataStructures\n",
     "s = dropdown(OrderedDict(\"a\" => \"Value 1\", \"b\" => \"Value 2\"))\n",
     "display(s)"
    ],
@@ -302,7 +301,7 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "using Plots, DataStructures\n",
+    "using Plots\n",
     "\n",
     "x = y = 0:0.1:30\n",
     "\n",
@@ -320,7 +319,7 @@
    "outputs": [],
    "cell_type": "markdown",
    "source": [
-    "## Layout\n",
+    "## Widget layout\n",
     "\n",
     "To create a full blown web-app, you should learn the layout tools that the CSS framework you are using provides. Both [Bulma](https://bulma.io/) and [UIkit](https://getuikit.com/) have modern layout tools for responsive design (of course, use Bulma if you're working with the Bulma backend and UIkit if you're working with the UIkit backend). You can use [WebIO](https://github.com/JuliaGizmos/WebIO.jl) to create from Julia the HTML required to create these layouts.\n",
     "\n",
@@ -332,7 +331,6 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "using CSSUtil\n",
     "loadbutton = filepicker()\n",
     "hellobutton = button(\"Hello!\")\n",
     "goodbyebutton = button(\"Good bye!\")\n",
@@ -404,7 +402,6 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "using CSSUtil\n",
     "function makebuttons(df)\n",
     "    buttons = button.(names(df))\n",
     "    dom\"div\"(hbox(buttons))\n",
@@ -453,7 +450,7 @@
    "outputs": [],
    "cell_type": "code",
    "source": [
-    "using CSV, DataFrames, InteractUIkit, WebIO, Observables, Plots, CSSUtil\n",
+    "using CSV, DataFrames, Interact, Plots\n",
     "loadbutton = filepicker()\n",
     "columnbuttons = Observable{Any}(dom\"div\"())\n",
     "data = Observable{Any}(DataFrame)\n",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,8 +8,11 @@ makedocs(
     authors = "JuliaGizmos",
     pages = [
         "Introduction" => "index.md",
+        "Observables" => "observables.md",
+        "Widgets" => "widgets.md",
+        "Layout" => "layout.md",
+        "Deploying the web app" => "deploying.md",
         "Tutorial" => "tutorial.md",
-        "API reference" => "api_reference.md",
     ]
 )
 

--- a/docs/src/deploying.md
+++ b/docs/src/deploying.md
@@ -1,0 +1,45 @@
+# Deploying the web app
+
+Interact works with the following frontends:
+
+- [Juno](http://junolab.org) - The hottest Julia IDE
+- [IJulia](https://github.com/JuliaLang/IJulia.jl) - Jupyter notebooks (and Jupyter Lab) for Julia
+- [Blink](https://github.com/JunoLab/Blink.jl) - An [Electron](http://electron.atom.io/) wrapper you can use to make Desktop apps
+- [Mux](https://github.com/JuliaWeb/Mux.jl) - A web server framework
+
+## Jupyter notebook/lab and Juno
+
+Simply use `display`:
+
+```julia
+using Interact
+ui = button()
+display(ui)
+```
+
+Note that using Interact in Jupyter Lab requires installing an extension first:
+
+```julia
+cd(Pkg.dir("WebIO", "assets"))
+;jupyter labextension install webio
+;jupyter labextension enable webio/jupyterlab_entry
+```
+
+## Electron window
+
+To deploy the app as a standalone Electron window, one would use [Blink.jl](https://github.com/JunoLab/Blink.jl):
+
+```julia
+using Interact, Blink
+w = Window()
+body!(w, ui);
+```
+
+## Browser
+
+The app can also be served in a webpage:
+
+```julia
+using Interact, Mux
+webio_serve(page("/", req -> ui), rand(8000:9000)) # serve on a random port
+```

--- a/docs/src/deploying.md
+++ b/docs/src/deploying.md
@@ -41,5 +41,5 @@ The app can also be served in a webpage:
 
 ```julia
 using Interact, Mux
-webio_serve(page("/", req -> ui), rand(8000:9000)) # serve on a random port
+WebIO.webio_serve(page("/", req -> ui), rand(8000:9000)) # serve on a random port
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,9 +4,17 @@ Interact allows to create small GUIs in Julia based on web technology. These GUI
 
 To understand how to use it go through the [Tutorial](@ref). The tutorial is also available [here](https://github.com/JuliaGizmos/Interact.jl/blob/master/doc/notebooks/tutorial.ipynb) as a Jupyter notebook.
 
-A list of available widget can be found at [API reference](@ref)
+[InteractBase](https://github.com/piever/InteractBase.jl), [Vue](https://github.com/JuliaGizmos/Vue.jl) and [WebIO](https://github.com/JuliaGizmos/WebIO.jl) provide the logic that allows the communication between Julia and Javascript and the organization of the widgets.
 
-InteractBase (together with [Vue](https://github.com/JuliaGizmos/Vue.jl) and [WebIO](https://github.com/JuliaGizmos/WebIO.jl)) provides the logic that allows the communication between Julia and Javascript and the organization of the widgets.
+## Overview
+
+Creating an app in Interact requires three ingredients:
+
+- [Observables](@ref): references that can listen to changes in other references
+- [Widgets](@ref): the graphical elements that make up the app
+- [Layout](@ref): tools to assemble together different widgets
+
+To get a quick overview of how these tools work together, go to [Tutorial](@ref).
 
 ## CSS frameworks
 
@@ -24,7 +32,7 @@ or
 settheme!(:uikit)
 ```
 
-## Deploying the web app
+## Deployment
 
 InteractBase works with the following frontends:
 
@@ -34,4 +42,4 @@ InteractBase works with the following frontends:
 - [Mux](https://github.com/JuliaWeb/Mux.jl) - A web server framework
 
 
-See [Displaying a widget](@ref) for instructions.
+See [Deploying the web app](@ref) for instructions.

--- a/docs/src/layout.md
+++ b/docs/src/layout.md
@@ -1,0 +1,16 @@
+# Layout
+
+Several utilities are provided to create and align
+various web elements on the DOM.
+
+## Example Usage
+```julia
+using Interact
+
+el1 =button("Hello world!")
+el2 = button("Goodbye world!")
+
+el3 = hbox(el1, el2) # aligns horizontally
+el4 = hline() # draws horizontal line
+el5 = vbox(el1, el2) # aligns vertically
+```

--- a/docs/src/observables.md
+++ b/docs/src/observables.md
@@ -1,0 +1,46 @@
+# Observables
+
+Observables are like `Ref`s but you can listen to changes.
+
+```@repl manual
+using Observables
+
+observable = Observable(0)
+
+h = on(observable) do val
+    println("Got an update: ", val)
+end
+
+observable[] = 42
+```
+
+To get the value of an observable index it with no arguments
+```@repl manual
+observable[]
+```
+
+To remove a handler use `off` with the return value of `on`:
+
+```@repl manual
+off(observable, h)
+```
+
+### How is it different from Reactive.jl?
+
+The main difference is `Signal`s are manipulated mostly by converting one signal to another. For example, with signals, you can construct a changing UI by creating a `Signal` of UI objects and rendering them as the signal changes. On the other hand, you can use an Observable both as an input and an output. You can arbitrarily attach outputs to inputs allowing structuring code in a [signals-and-slots](http://doc.qt.io/qt-4.8/signalsandslots.html) kind of pattern.
+
+Another difference is Observables are synchronous, Signals are asynchronous. Observables may be better suited for an imperative style of programming.
+
+## API
+
+```@docs
+Observable{T}
+on(f, o::Observable)
+off(o::Observable, f)
+Base.setindex!(o::Observable, val)
+Base.getindex(o::Observable)
+onany(f, os...)
+Base.map!(f, o::Observable, os...)
+connect!(o1::Observable, o2::Observable)
+Base.map(f, o::Observable, os...; init)
+```

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -12,7 +12,7 @@
 # The basic behavior is as follows: Interact provides a series of widgets, each widgets has a primary observable that can be obtained with `observe(widget)` and adding listeners to that observable one can provide behavior. Let's see this in practice.
 #
 # ## Displaying a widget
-using Interact, WebIO
+using Interact
 ui = button()
 display(ui)
 
@@ -63,7 +63,6 @@ togglebuttons(["a", "b", "c"]) |> display # Observable is option selected
 radiobuttons(["a", "b", "c"]) |> display # Observable is option selected
 
 # The option widgets can also take as input a dictionary (ordered dictionary is preferrable, to avoid items getting scrambled), in which case the label displays the key while the observable stores the value:
-using DataStructures
 s = dropdown(OrderedDict("a" => "Value 1", "b" => "Value 2"))
 display(s)
 #-
@@ -89,7 +88,7 @@ ui = @manipulate for nsamples in 1:200,
     )
 end
 # or, if you want a plot with some variables taking discrete values:
-using Plots, DataStructures
+using Plots
 
 x = y = 0:0.1:30
 
@@ -100,12 +99,11 @@ mp = @manipulate for freq1 in freqs, freq2 in slider(0.01:0.1:4π; label="freq2"
     plot(x, y)
 end
 
-# ## Layout
+# ## Widget layout
 #
 # To create a full blown web-app, you should learn the layout tools that the CSS framework you are using provides. Both [Bulma](https://bulma.io/) and [UIkit](https://getuikit.com/) have modern layout tools for responsive design (of course, use Bulma if you're working with the Bulma backend and UIkit if you're working with the UIkit backend). You can use [WebIO](https://github.com/JuliaGizmos/WebIO.jl) to create from Julia the HTML required to create these layouts.
 #
 # However, this can be overwhelming at first (especially for users with no prior experience in web design). A simpler solution is [CSSUtil](https://github.com/JuliaGizmos/CSSUtil.jl), a package that provides some tools to create simple layouts.
-using CSSUtil
 loadbutton = filepicker()
 hellobutton = button("Hello!")
 goodbyebutton = button("Good bye!")
@@ -134,7 +132,6 @@ data = Observable{Any}(DataFrame)
 map!(CSV.read, data, observe(loadbutton))
 #
 # Now as soon as a file is uploaded, the `Observable` `data` gets updated with the correct value. Now, as soon as `data` is updated, we want to update our buttons.
-using CSSUtil
 function makebuttons(df)
     buttons = button.(names(df))
     dom"div"(hbox(buttons))
@@ -154,7 +151,7 @@ function makebuttons(df)
 end
 #
 # To put it all together:
-using CSV, DataFrames, InteractUIkit, WebIO, Observables, Plots, CSSUtil
+using CSV, DataFrames, Interact, Plots
 loadbutton = filepicker()
 columnbuttons = Observable{Any}(dom"div"())
 data = Observable{Any}(DataFrame)

--- a/docs/src/tutorial.jl
+++ b/docs/src/tutorial.jl
@@ -27,7 +27,7 @@ w = Window()
 body!(w, ui);
 # The app can also be served in a webpage via [Mux.jl](https://github.com/JuliaWeb/Mux.jl):
 using Mux
-webio_serve(page("/", req -> ui), rand(8000:9000)) # serve on a random port
+WebIO.webio_serve(page("/", req -> ui), rand(8000:9000)) # serve on a random port
 #
 # ## Adding behavior
 # For now this button doesn't do anything. This can be changed by adding callbacks to its primary observable:

--- a/docs/src/widgets.md
+++ b/docs/src/widgets.md
@@ -1,4 +1,4 @@
-# API reference
+# Widgets
 
 ## Text input
 

--- a/src/Interact.jl
+++ b/src/Interact.jl
@@ -8,6 +8,12 @@ using Reexport
 
 import InteractUIkit, InteractBulma
 
+@reexport using DataStructures
+@reexport using Observables
+@reexport using Vue
+@reexport using CSSUtil
+@reexport using WebIO
+
 const themes = Dict(
     :uikit => InteractUIkit.UIkit(),
     :bulma => InteractBulma.Bulma()


### PR DESCRIPTION
This effectively turns Interact into a metapackage reexporting most of JuliaGizmos. The main advantages are:

- The user only needs `using Interact` without worrying about how things are internally organized (meaning, where are `Observables` defined or where does `hbox` come from)
- Documentation can be unified here