### PR TITLE
Use Euler's constant symbol

### DIFF
--- a/doc/notebooks/02-Widgets Overview.ipynb
+++ b/doc/notebooks/02-Widgets Overview.ipynb
@@ -239,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "map(g -> g(e, π*im), observe(f_))"
+    "map(g -> g(ℯ, π*im), observe(f_))"
    ]
   },
   {


### PR DESCRIPTION
`e` -> `ℯ` 

Using `e` results in
```
UndefVarError: e not defined

Stacktrace:
 [1] top-level scope at In[17]:1
```