### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ using Mux, WebIO
 function app(req) # req is a Mux request dictionary
  ...
 end
-webio_serve(page("/", app), port=8000) # this will serve at http://localhost:8000/
+webio_serve(page("/", app), 8000) # this will serve at http://localhost:8000/
 ```
 
 ### Bonus: Publish something to Heroku!


### PR DESCRIPTION
`Mux.serve` does not accept kwargs in latest version. Positional argument works.