### PR TITLE
Reform compat section, add CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,26 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "2"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Interact"
 uuid = "c601a237-2ae4-5e1e-952c-7a85b0c7eef1"
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 CSSUtil = "70588ee8-6100-5070-97c1-3cb50ed05fe8"
@@ -14,14 +14,16 @@ WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 Widgets = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
 
 [compat]
-julia = "0.7, 1"
-JSON = "≥ 0.7"
-InteractBase = "≥ 0.10.1"
-WebIO = "≥ 0.3.1"
+CSSUtil = "0.1"
+InteractBase = "0.10.1"
+JSON = "0.18, 0.19, 0.20, 0.21"
+Knockout = "0.1.3, 0.2"
+Observables = "0.2.2, 0.3, 0.4"
 OrderedCollections = "1"
-Widgets = "≥ 0.5.0"
-Reexport = "≥ 0.1.0"
-Observables = "≥ 0.2.2"
+Reexport = "0.2, 1"
+WebIO = "0.3.1, 0.4, 0.6, 0.7, 0.8"
+Widgets = "0.5, 0.6"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This reforms the compat section to be more explicit with an upper bound. The registry has added an upper bound to prior versions of this package:
https://github.com/JuliaRegistries/General/blob/60bdb5a38cb0be44a4c110129fd57fc3e4f81938/I/Interact/Compat.toml#L31

The upper bound now needs updating.

This also adds CompatHelper. Please follow the instructions at https://juliaregistries.github.io/CompatHelper.jl/dev/ to complete the process.